### PR TITLE
Implementing content for projects page

### DIFF
--- a/js/projects.js
+++ b/js/projects.js
@@ -1,0 +1,13 @@
+function makeGhCard(username, repo) {
+    return '<div class="col-md-4"><iframe frameborder="0" scrolling="0" allowtransparency="true" src="https://cdn.jsdelivr.net/github-cards/1.0.2/cards/default.html?user=' + username + '&repo=' + repo + '"></iframe><script src="https://cdn.jsdelivr.net/github-cards/1.0.2/widget.js"></script></div>'
+};
+
+var projects = $.getJSON("js/projects.json", function (data) {
+    var items = [];
+    $.each(data, function (key, val) {
+        for(i = 0; i < val.length; i++){
+            console.log(key + " " + val[i]);
+            $("#projects").append(makeGhCard(key, val[i]));
+        }
+    });
+});

--- a/js/projects.json
+++ b/js/projects.json
@@ -1,0 +1,3 @@
+{
+    "kerosenecity" : [ "DevilWhisperer", "LudumDare40" ]
+}

--- a/js/projects.json
+++ b/js/projects.json
@@ -1,3 +1,3 @@
 {
-    "kerosenecity" : [ "DevilWhisperer", "LudumDare40" ]
+    "Nandob777" : [ "BudgetApp", "comp3490", "Monte-Carlo-Normal-Distribution-Demo" ]
 }

--- a/js/projects.json
+++ b/js/projects.json
@@ -1,3 +1,3 @@
 {
-    "Nandob777" : [ "BudgetApp", "comp3490", "Monte-Carlo-Normal-Distribution-Demo" ]
+    "Nandob777" : [ "BudgetApp", "Monte-Carlo-Normal-Distribution-Demo" ]
 }

--- a/projects.html
+++ b/projects.html
@@ -107,6 +107,7 @@
 
 <!-- Own JS scripts -->
 <script src="js/devclubJS.js"></script>
+<script src="js/projects.js"></script>
 
 </body>
 

--- a/projects.html
+++ b/projects.html
@@ -79,10 +79,6 @@
     <div class="featurette" id="projects">
         <div>
             <h2 class="featurette-heading">Projects</h2>
-            <br>
-            <hr>
-            <br>
-            <h4 style="text-align: center;">Coming Soon!!</h4>
         </div>
     </div>
     <hr>


### PR DESCRIPTION
resolves nothing yet
related to issue #23 

## Problem

Our projects page has no content

## Solution

We can load in descriptions of projects from github repos, by added usernames and repos to js/projects.json.  In effect, this s very simple project management.

## Implementation

[Github Cards](https://github.com/lepture/github-cards) are used to display repo information.  The information they display comes from a json file, js.projects.json.
JQuery is used to both read the json file, and to call the function which formats the given date.
JQuery is then used to insert the formatted output (html) data into the projects page.
All the javascript which handles this is in js/projects.js

## Screenshots

TBH I was too lazy to take screenshots, so please see 'Testing' for a preview

## Testing

To test this I hosted my fork [here](https://nandob777.github.io/devClub/projects.html) using two of @kerosenecity 's repos.

## Problems

Some problems persist, which is why I'm doing a PR into a new branch.  No matter what the project page solution is, we need people to weigh in on content, design, and implementation of the webpage before a merge into master, which is too large of a focus for a single change.  I propose that we work on the projects page on this branch, and when it's up-to-snuff we merge it with master