### PR TITLE
feat: Add /devhacks/2027 page

### DIFF
--- a/sitemap.txt
+++ b/sitemap.txt
@@ -1,5 +1,6 @@
 https://devclub.ca/?/
 https://devclub.ca/?/devhacks
+https://devclub.ca/?/devhacks/2027
 https://devclub.ca/?/devhacks/2023
 https://devclub.ca/?/devhacks/2024
 https://devclub.ca/?/devhacks/2024/schedule

--- a/src/routes/App.tsx
+++ b/src/routes/App.tsx
@@ -14,6 +14,7 @@ import Contact from "./Contact";
 import DevChamps from "./DevChamps";
 import GitHub from "./Github";
 import Hackathon from "./hackathon/Hackathon";
+import Hackathon2027 from "./hackathon/Hackathon2027";
 import HackathonArchive from "./hackathon/HackathonArchive";
 import {
   hackathonInfoLoader,
@@ -49,6 +50,7 @@ const router = createBrowserRouter(
       <Route path="/github-tutorial" element={<GitHub />} />
       <Route path="/link-tree" element={<LinkTree />} />
       <Route path="/devhacks" element={<Hackathon />} />
+      <Route path="/devhacks/2027" element={<Hackathon2027 />} />
       <Route path="/events" element={<Events />} />
       <Route path="/merch" element={<Merch />} />
       <Route

--- a/src/routes/hackathon/Hackathon2027.tsx
+++ b/src/routes/hackathon/Hackathon2027.tsx
@@ -1,0 +1,48 @@
+import "@/styles/Hackathon.scss";
+
+import { Button } from "@mui/material";
+
+function Hackathon2027() {
+  return (
+    <div className="hackathon-container" dir="ltr">
+      <div className="hackathon-welcome container">
+        <h1 className="hackathon-welcome heading">&lt;.devHacks 2027&gt;</h1>
+        <h2
+          className="hackathon-welcome description"
+          style={{ textAlign: "center" }}
+        >
+          {"Manitoba's largest "}
+          <del>24-hour</del>{" "}
+          <strong>
+            <em>48-hour</em>
+          </strong>{" "}
+          hackathon.
+        </h2>
+        <h2 className="hackathon-welcome sub-heading">
+          📅 Feb. 19 - 21, 2027
+          <br />
+          📍 Engineering, Information and Technology Complex, University of
+          Manitoba, Winnipeg, MB
+        </h2>
+        <div
+          className="hackathon-welcome btn-wrapper"
+          style={{ justifyContent: "center" }}
+        >
+          <Button
+            variant="contained"
+            sx={{
+              fontSize: "1.5rem",
+              fontFamily: "inherit",
+              mt: 3,
+              textTransform: "none",
+            }}
+          >
+            COMING SOON
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Hackathon2027;


### PR DESCRIPTION
## Information

Added `/devhacks/2027` route to the website. Visible on sitemap, no natural navigation option. Only for the MLH Event Membership submission.

## Preview

<img width="956" height="964" alt="image" src="https://github.com/user-attachments/assets/a3f60906-0ded-4193-bce5-ae34b81276e4" />

## Verification

* Ran `npm run build`.
* Tested using `npm run start` and `npm run preview`.